### PR TITLE
Update errors.go

### DIFF
--- a/services/errors.go
+++ b/services/errors.go
@@ -182,6 +182,8 @@ func wrapErr(rErr *types.Error, err error) *types.Error {
 	newErr := &types.Error{
 		Code:    rErr.Code,
 		Message: rErr.Message,
+		Retriable: rErr.Retriable,
+		
 	}
 	if err != nil {
 		newErr.Details = map[string]interface{}{

--- a/services/errors.go
+++ b/services/errors.go
@@ -183,7 +183,6 @@ func wrapErr(rErr *types.Error, err error) *types.Error {
 		Code:    rErr.Code,
 		Message: rErr.Message,
 		Retriable: rErr.Retriable,
-		
 	}
 	if err != nil {
 		newErr.Details = map[string]interface{}{


### PR DESCRIPTION
fix wrapErr

Fixes # .

### Motivation
When a error is wrapped Retriable is not set 
